### PR TITLE
Adicionando um pop-up para facilitar a permissão de notificações push

### DIFF
--- a/front-end/src/App.vue
+++ b/front-end/src/App.vue
@@ -2,6 +2,7 @@
   <div class="app-container">
     <AppTemplate/>
     <InstallAppPrompt />
+    <NotificationPrompt />
   </div>
 </template>
 
@@ -9,6 +10,7 @@
 import { useRegisterSW } from 'virtual:pwa-register/vue';
 import AppTemplate from "./pages/AppTemplate.vue";
 import InstallAppPrompt from "./components/InstallAppPrompt.vue";
+import NotificationPrompt from "./components/NotificationPrompt.vue";
 
 // Quando um novo Service Worker está disponível e assumiu o controle
 // (graças ao skipWaiting + clients.claim no SW), esta callback é chamada.

--- a/front-end/src/components/InstallAppPrompt.vue
+++ b/front-end/src/components/InstallAppPrompt.vue
@@ -2,7 +2,7 @@
   <q-dialog v-model="showPrompt" position="bottom" seamless>
     <q-card style="width: 100%; border-radius: 16px 16px 0 0;" class="bg-primary text-white install-card">
       <div class="row items-center q-pa-md pb-0">
-        <q-icon name="get_app" size="3.5rem" class="q-mr-md" />
+        <q-icon name="fa-solid fa-download" size="3.5rem" class="q-mr-md" />
         <div class="col">
           <div class="text-h6 text-weight-bold" style="line-height: 1.2;">Instale o App</div>
           <div class="text-caption q-mt-xs text-weight-medium" v-if="!isIOS" style="opacity: 0.9;">
@@ -24,8 +24,9 @@
 
 <script setup>
 import { ref, onMounted } from 'vue'
+import { isInstallPromptVisible } from '../composables/useUIState'
 
-const showPrompt = ref(false)
+const showPrompt = isInstallPromptVisible
 const deferredPrompt = ref(null)
 const isIOS = ref(false)
 

--- a/front-end/src/components/NotificationPrompt.vue
+++ b/front-end/src/components/NotificationPrompt.vue
@@ -1,0 +1,122 @@
+<template>
+  <q-dialog v-model="showPrompt" position="bottom" seamless>
+    <q-card style="width: 100%; border-radius: 16px 16px 0 0;" class="bg-secondary text-white notify-card">
+      <div class="row items-center q-pa-md pb-0">
+        <q-icon name="fa-solid fa-bell" size="3.5rem" class="q-mr-md" />
+        <div class="col">
+          <div class="text-h6 text-weight-bold" style="line-height: 1.2;">Ative as Notificações</div>
+          <div class="text-caption q-mt-xs text-weight-medium" style="opacity: 0.9;">
+            Fique por dentro das escalas, comunicados e atualizações em tempo real.
+          </div>
+        </div>
+      </div>
+      
+      <q-card-actions align="right" class="q-pt-sm q-pb-md q-px-md">
+        <q-btn flat label="Mais Tarde" color="white" class="opacity-80" @click="dismissPrompt" />
+        <q-btn flat rounded label="Ativar" color="secondary" class="bg-white text-weight-bold q-px-md" @click="enableNotifications" />
+      </q-card-actions>
+    </q-card>
+  </q-dialog>
+</template>
+
+<script setup>
+import { ref, onMounted, watch } from 'vue'
+import { useNotifications } from '../composables/useNotifications'
+import { useAuthStore } from '../stores/authStore'
+import { isInstallPromptVisible } from '../composables/useUIState'
+
+const showPrompt = ref(false)
+const { isSupported, permissionGranted, requestPermission } = useNotifications()
+const authStore = useAuthStore()
+
+const checkAndShowPrompt = () => {
+  // Apenas tentar exibir se:
+  // 1. Há suporte
+  // 2. Não tem permissão ainda
+  // 3. Usuário está logado
+  if (!isSupported.value || permissionGranted.value || !authStore.isAuthenticated) {
+    return
+  }
+
+  // Verifica se o browser suporta checar permissão e se a permissão não foi negada pelo SO
+  const currentPermission = ('Notification' in window) ? Notification.permission : 'denied'
+  if (currentPermission === 'denied' || currentPermission === 'granted') {
+    return
+  }
+
+  const dismissData = localStorage.getItem('wh-notify-prompt-dismissed')
+  let hasDismissed = false
+  
+  if (dismissData) {
+    const dismissTime = parseInt(dismissData, 10)
+    const sevenDaysInMs = 7 * 24 * 60 * 60 * 1000
+    
+    if (!isNaN(dismissTime) && (Date.now() - dismissTime < sevenDaysInMs)) {
+      hasDismissed = true
+    } else {
+      localStorage.removeItem('wh-notify-prompt-dismissed')
+    }
+  }
+
+  if (!hasDismissed) {
+    // Atraso de 4 segundos para evitar poluição visual imediata com outros possíveis alertas no login
+    setTimeout(() => {
+      const currentPermissionAft = ('Notification' in window) ? Notification.permission : 'denied'
+      if (authStore.isAuthenticated && currentPermissionAft === 'default') {
+        if (!isInstallPromptVisible.value) {
+          showPrompt.value = true
+        } else {
+          // Se o pop-up de instalação estiver visível, aguardar até que seja fechado
+          const unwatch = watch(isInstallPromptVisible, (isVisible) => {
+            if (!isVisible) {
+              setTimeout(() => { showPrompt.value = true }, 500)
+              unwatch()
+            }
+          })
+        }
+      }
+    }, 4000)
+  }
+}
+
+onMounted(() => {
+  checkAndShowPrompt()
+})
+
+// Também observamos quando a pessoa logar, caso não haja refresh da página na home
+watch(() => authStore.isAuthenticated, (newVal) => {
+  if (newVal) {
+    checkAndShowPrompt()
+  } else {
+    showPrompt.value = false
+  }
+})
+
+const dismissPrompt = () => {
+  showPrompt.value = false
+  localStorage.setItem('wh-notify-prompt-dismissed', Date.now().toString())
+}
+
+const enableNotifications = async () => {
+  showPrompt.value = false
+  await requestPermission()
+  
+  // Se o usuário interagiu e no final recusou no prompt nativo ('denied')
+  // não precisamos necessariamente salvar os 7 dias porque o navegador não deixará perguntar novamente de qualquer maneira.
+  // Porém, por segurança, registramos que houve uma tomada de ação.
+  const currentPermission = ('Notification' in window) ? Notification.permission : 'denied'
+  if (currentPermission !== 'granted') {
+     localStorage.setItem('wh-notify-prompt-dismissed', Date.now().toString())
+  }
+}
+</script>
+
+<style scoped>
+.notify-card {
+  box-shadow: 0 -4px 16px rgba(0, 0, 0, 0.2);
+  padding-bottom: env(safe-area-inset-bottom);
+}
+.opacity-80 {
+  opacity: 0.8;
+}
+</style>

--- a/front-end/src/composables/useUIState.js
+++ b/front-end/src/composables/useUIState.js
@@ -1,0 +1,3 @@
+import { ref } from 'vue';
+
+export const isInstallPromptVisible = ref(false);


### PR DESCRIPTION
Adicionando um pop-up para facilitar a permissão de notificações push.
- Feita a comunicação entre os pop-ups para que não haja sobreposição

Closes #29 