### PR TITLE
Escolha de tom para músicas no repertório

### DIFF
--- a/back-end/WorshipApi/Controllers/ScheduleController.cs
+++ b/back-end/WorshipApi/Controllers/ScheduleController.cs
@@ -154,12 +154,12 @@ namespace WorshipApi.Controllers
         [AuthorizeRoles(Role.Admin, Role.Leader, Role.Minister)]
         public ActionResult SaveRepertoire(
             [FromServices] ScheduleService _scheduleService,
-            [FromBody] int[] musicIds,
+            [FromBody] IEnumerable<ScheduleTrackInputDto> tracks,
             int id)
         {
             try
             {
-                _scheduleService.SaveScheduleRepertoire(id, musicIds ?? Array.Empty<int>());
+                _scheduleService.SaveScheduleRepertoire(id, tracks ?? Enumerable.Empty<ScheduleTrackInputDto>());
                 return Ok();
             }
             catch (Exception ex)

--- a/back-end/WorshipApplication/Services/ScheduleService.cs
+++ b/back-end/WorshipApplication/Services/ScheduleService.cs
@@ -220,9 +220,9 @@ namespace WorshipApplication.Services
             return _repository.GetScheduleRepertoireDetails(scheduleId);
         }
 
-        public void SaveScheduleRepertoire(int scheduleId, IEnumerable<int> musicIds)
+        public void SaveScheduleRepertoire(int scheduleId, IEnumerable<ScheduleTrackInputDto> tracks)
         {
-            _repository.SaveScheduleRepertoire(scheduleId, musicIds);
+            _repository.SaveScheduleRepertoire(scheduleId, tracks);
         }
 
         public SchedulesAssignmentsDetailsDto? GetSchedulesAssignmentsDetails(IEnumerable<int> scheduleIds)

--- a/back-end/WorshipDomain/DTO/HomePage/HomeMusicDto.cs
+++ b/back-end/WorshipDomain/DTO/HomePage/HomeMusicDto.cs
@@ -1,11 +1,15 @@
-﻿namespace WorshipDomain.DTO.HomePage
+namespace WorshipDomain.DTO.HomePage
 {
     public class HomeMusicDto
     {
         public int Id { get; set; }
         public string Title { get; set; } = "";
         public string? Artist { get; set; }
-        public string? Details { get; set; }
+        public string? NoteBase { get; set; }
+        public string? NoteMode { get; set; }
+        public decimal? Bpm { get; set; }
+        public string? TimeSignature { get; set; }
+        public int? DurationSeconds { get; set; }
         public string? ImageUrl { get; set; }
     }
 }

--- a/back-end/WorshipDomain/DTO/Music/MusicOverviewDTO.cs
+++ b/back-end/WorshipDomain/DTO/Music/MusicOverviewDTO.cs
@@ -1,4 +1,4 @@
-﻿namespace WorshipDomain.DTO.Music
+namespace WorshipDomain.DTO.Music
 {
     public class MusicOverviewDTO
     {
@@ -6,5 +6,8 @@
         public string Title { get; set; }
         public string Artist { get; set; }
         public string Album { get; set; }
+        public string? NoteBase { get; set; }
+        public string? NoteMode { get; set; }
+        public decimal? Bpm { get; set; }
     }
 }

--- a/back-end/WorshipDomain/DTO/Schedule/ScheduleTrackInputDto.cs
+++ b/back-end/WorshipDomain/DTO/Schedule/ScheduleTrackInputDto.cs
@@ -1,0 +1,9 @@
+namespace WorshipDomain.DTO.Schedule
+{
+    public class ScheduleTrackInputDto
+    {
+        public int MusicId { get; set; }
+        public string? NoteBase { get; set; }
+        public decimal? Bpm { get; set; }
+    }
+}

--- a/back-end/WorshipDomain/Entities/ScheduleMusic.cs
+++ b/back-end/WorshipDomain/Entities/ScheduleMusic.cs
@@ -1,4 +1,4 @@
-﻿using System.ComponentModel.DataAnnotations.Schema;
+using System.ComponentModel.DataAnnotations.Schema;
 
 namespace WorshipDomain.Entities
 {
@@ -16,5 +16,14 @@ namespace WorshipDomain.Entities
 
         [Column("order")]
         public int Order { get; set; }
+
+        [Column("note_base")]
+        public string? NoteBase { get; set; }
+
+        [Column("note_mode")]
+        public string? NoteMode { get; set; }
+
+        [Column("bpm")]
+        public decimal? Bpm { get; set; }
     }
 }

--- a/back-end/WorshipDomain/Repository/IScheduleRepository.cs
+++ b/back-end/WorshipDomain/Repository/IScheduleRepository.cs
@@ -11,7 +11,7 @@ namespace WorshipDomain.Repository
         bool ExistSchedule(DateTime date, EventType eventType);
         ResultFilter<ScheduleOverviewDTO> GetListPaged(ApiRequest<ScheduleFilterDTO> request);
         ScheduleRepertoireDto GetScheduleRepertoireDetails(int scheduleId);
-        void SaveScheduleRepertoire(int scheduleId, IEnumerable<int> musicIds);
+        void SaveScheduleRepertoire(int scheduleId, IEnumerable<ScheduleTrackInputDto> tracks);
         SchedulesAssignmentsDetailsDto? GetSchedulesAssignmentsDetails(IEnumerable<int> scheduleIds);
         void SaveAssignments(int scheduleId, Dictionary<int, List<int>> assignments);
         void UpdateStatus(IEnumerable<int> scheduleIds, int newStatus);

--- a/back-end/WorshipInfra/Repository/HomeRepository.cs
+++ b/back-end/WorshipInfra/Repository/HomeRepository.cs
@@ -1,4 +1,4 @@
-﻿using Dapper;
+using Dapper;
 using WorshipDomain.DTO.HomePage;
 using WorshipDomain.Entities;
 using WorshipDomain.Enums;
@@ -57,7 +57,11 @@ namespace WorshipInfra.Repository
 
                 // load musics for schedule (fallback to empty)
                 const string musicsSql = @"
-                    SELECT m.id, m.title, m.artist, m.note_base, m.note_mode, m.bpm, m.time_signature, m.duration_seconds, m.image_url
+                    SELECT m.id, m.title, m.artist, 
+                           COALESCE(sm.note_base, m.note_base) as note_base, 
+                           m.note_mode as note_mode, 
+                           COALESCE(sm.bpm, m.bpm) as bpm, 
+                           m.time_signature, m.duration_seconds, m.image_url
                     FROM schedules_musics sm
                     JOIN musics m ON m.id = sm.music_id
                     WHERE sm.schedule_id = @ScheduleId
@@ -69,7 +73,11 @@ namespace WorshipInfra.Repository
                     Id = (int)m.id,
                     Title = (string)m.title,
                     Artist = m.artist as string,
-                    Details = BuildMusicDetails(m),
+                    NoteBase = m.note_base as string,
+                    NoteMode = m.note_mode as string,
+                    Bpm = m.bpm as decimal?,
+                    TimeSignature = m.time_signature as string,
+                    DurationSeconds = m.duration_seconds as int?,
                     ImageUrl = m.image_url as string
                 }).ToList();
 
@@ -77,20 +85,6 @@ namespace WorshipInfra.Repository
             }
 
             return result;
-        }
-
-        private static string BuildMusicDetails(dynamic m)
-        {
-            var parts = new List<string>();
-            if (m.note_base != null) parts.Add($"Tom: {m.note_base}{(m.note_mode == "minor" ? "m" : string.Empty)}");
-            if (m.bpm != null) parts.Add($"BPM: {m.bpm}");
-            if (m.time_signature != null) parts.Add($"Tempo: {m.time_signature}");
-            if (m.duration_seconds != null)
-            {
-                int secs = (int)m.duration_seconds;
-                parts.Add($"Duração: {secs / 60}:{secs % 60:D2}");
-            }
-            return string.Join(' ', parts);
         }
     }
 }

--- a/back-end/WorshipInfra/Repository/MusicRepository.cs
+++ b/back-end/WorshipInfra/Repository/MusicRepository.cs
@@ -1,4 +1,4 @@
-﻿using Dapper;
+using Dapper;
 using WorshipDomain.Core.Entities;
 using WorshipDomain.DTO.Music;
 using WorshipDomain.Entities;
@@ -18,7 +18,7 @@ namespace WorshipInfra.Repository
 
             var selector = builder.AddTemplate($@"
 SELECT SQL_CALC_FOUND_ROWS
-    id, title, artist, album
+    id, title, artist, album, note_base, note_mode, bpm
 FROM musics
 /**where**/
 /**orderby**/
@@ -42,13 +42,16 @@ SELECT FOUND_ROWS() AS TotalRecords;");
 
             using (var multiReader = _dbConnection.QueryMultiple(selector.RawSql, selector.Parameters))
             {
-                var musicList = multiReader.Read<(int Id, string Title, string Artist, string Album)>();
+                var musicList = multiReader.Read<(int Id, string Title, string Artist, string Album, string? NoteBase, string? NoteMode, decimal? Bpm)>();
                 musicOverviewDTO = musicList.Select(music => new MusicOverviewDTO
                 {
                     Id = music.Id,
                     Title = music.Title,
                     Artist = music.Artist,
-                    Album = music.Album
+                    Album = music.Album,
+                    NoteBase = music.NoteBase,
+                    NoteMode = music.NoteMode,
+                    Bpm = music.Bpm
                 });
 
                 count = multiReader.ReadSingle<int>();

--- a/back-end/WorshipInfra/Repository/ScheduleRepository.cs
+++ b/back-end/WorshipInfra/Repository/ScheduleRepository.cs
@@ -136,9 +136,9 @@ SELECT FOUND_ROWS() AS TotalRecords;");
                 m.title AS Title,
                 m.artist as Artist,
                 m.album AS Album,
-                m.note_base AS NoteBase,
+                COALESCE(sm.note_base, m.note_base) AS NoteBase,
                 m.note_mode AS NoteMode,
-                m.bpm AS Bpm,
+                COALESCE(sm.bpm, m.bpm) AS Bpm,
                 m.time_signature AS TimeSignature,
                 m.duration_seconds AS DurationSeconds,
                 m.video_url AS VideoUrl
@@ -161,7 +161,7 @@ SELECT FOUND_ROWS() AS TotalRecords;");
             return scheduleRepertoireDto;
         }
 
-        public void SaveScheduleRepertoire(int scheduleId, IEnumerable<int> musicIds)
+        public void SaveScheduleRepertoire(int scheduleId, IEnumerable<ScheduleTrackInputDto> tracks)
         {
             var openedHere = false;
             try
@@ -179,14 +179,20 @@ SELECT FOUND_ROWS() AS TotalRecords;");
                     _dbConnection.Execute(deleteSql, new { ScheduleId = scheduleId }, tx);
 
                     const string insertSql = @"
-                    INSERT INTO schedules_musics (schedule_id, music_id, `order`)
-                    VALUES (@ScheduleId, @MusicId, @Order);";
+                    INSERT INTO schedules_musics (schedule_id, music_id, note_base, bpm, `order`)
+                    VALUES (@ScheduleId, @MusicId, @NoteBase, @Bpm, @Order);";
 
                     int order = 0;
-                    foreach (var mid in musicIds ?? Enumerable.Empty<int>())
+                    foreach (var track in tracks ?? Enumerable.Empty<ScheduleTrackInputDto>())
                     {
                         order++;
-                        _dbConnection.Execute(insertSql, new { ScheduleId = scheduleId, MusicId = mid, Order = order }, tx);
+                        _dbConnection.Execute(insertSql, new { 
+                            ScheduleId = scheduleId, 
+                            MusicId = track.MusicId, 
+                            NoteBase = track.NoteBase,
+                            Bpm = track.Bpm,
+                            Order = order 
+                        }, tx);
                     }
 
                     tx.Commit();

--- a/front-end/src/components/HomePage.vue
+++ b/front-end/src/components/HomePage.vue
@@ -68,7 +68,12 @@
                 <q-item-section class="music-content">
                   <q-item-label class="music-title">{{ music.title }}</q-item-label>
                   <q-item-label class="music-artist">{{ music.artist }}</q-item-label>
-                  <q-item-label class="music-details">{{ music.details }}</q-item-label>
+                  <q-item-label class="music-details row">
+                    <span v-if="music.noteBase" class="q-mr-sm"><strong>Tom:</strong> {{ music.noteBase }}{{ music.noteMode === 'minor' ? 'm' : '' }}</span>
+                    <span v-if="music.bpm" class="q-mr-sm"><strong>BPM:</strong> {{ Math.round(music.bpm) }}</span>
+                    <span v-if="music.timeSignature" class="q-mr-sm"><strong>Tempo:</strong> {{ music.timeSignature }}</span>
+                    <span v-if="music.durationSeconds"><strong>Duração:</strong> {{ Math.floor(music.durationSeconds / 60) }}:{{ String(music.durationSeconds % 60).padStart(2, '0') }}</span>
+                  </q-item-label>
                 </q-item-section>
               </q-item>
             </q-list>

--- a/front-end/src/components/InstallAppPrompt.vue
+++ b/front-end/src/components/InstallAppPrompt.vue
@@ -9,7 +9,7 @@
             Acesso rápido e melhor experiência de uso na sua tela inicial.
           </div>
           <div class="text-caption q-mt-xs text-weight-medium" v-else style="opacity: 0.9;">
-            Para instalar, toque em <q-icon name="ios_share" size="sm" class="q-mx-xs" /> e selecione <br><strong>Adicionar à Tela de Início</strong>.
+            Para instalar, toque em <q-icon name="fa-solid fa-arrow-up-from-bracket" size="sm" class="q-mx-xs" /> e selecione <br><strong>Adicionar à Tela de Início</strong>.
           </div>
         </div>
       </div>
@@ -63,7 +63,7 @@ onMounted(() => {
     if (!hasDismissed) {
       setTimeout(() => {
         showPrompt.value = true
-      }, 3000)
+      }, 1000)
     }
   })
 
@@ -74,7 +74,7 @@ onMounted(() => {
       // Delay de alguns segundos para não ser intrusivo logo no primeiro load
       setTimeout(() => {
         showPrompt.value = true
-      }, 3000)
+      }, 1000)
     }
   }
 })

--- a/front-end/src/components/ManageScheduleRepertoire.vue
+++ b/front-end/src/components/ManageScheduleRepertoire.vue
@@ -24,40 +24,103 @@
         </div>
 
         <div class="q-mb-md">
-          <div class="text-subtitle2 q-mb-xs">Selecionar músicas</div>
-          <q-select
-            v-model="selectedTracks"
-            dense
-            outlined
-            multiple
-            use-chips
-            stack-label
-            :options="availableTracksOptions"
-            option-value="id"
-            option-label="label"
-            map-options
-            emit-value
-            input-debounce="200"
-            filter
-            :filter-method="filterTracks"
-            placeholder="Pesquisar e selecionar músicas"
-          />
+          <div class="row items-center justify-between q-mb-sm">
+            <div class="text-subtitle2">Músicas do Repertório</div>
+            <q-btn color="primary" icon="fa fa-plus" label="Adicionar Música" size="sm" @click="dialogMusicList = true" />
+          </div>
+
+          <q-list bordered separator class="rounded-borders">
+            <q-item v-for="(track, index) in schedule.repertoire" :key="index">
+              <q-item-section>
+                <q-item-label>{{ track.title }} <span class="text-caption text-grey" v-if="track.artist">— {{ track.artist }}</span></q-item-label>
+                <q-item-label caption>
+                  Tom: <strong>{{ formatKey(track.noteBase, track.noteMode) }}</strong> | BPM: <strong>{{ track.bpm || '--' }}</strong>
+                </q-item-label>
+              </q-item-section>
+              <q-item-section side>
+                <div class="row q-gutter-xs">
+                  <q-btn flat dense round icon="fa fa-cog" color="primary" @click="openConfigTrack(index)" />
+                  <q-btn flat dense round icon="fa fa-trash" color="negative" @click="removeTrack(index)" />
+                </div>
+              </q-item-section>
+            </q-item>
+            <q-item v-if="schedule.repertoire.length === 0">
+              <q-item-section class="text-grey text-center q-pa-md">Nenhuma música adicionada</q-item-section>
+            </q-item>
+          </q-list>
         </div>
 
-        <div v-if="!hideFooter" class="row justify-end q-gutter-sm">
+        <div v-if="!hideFooter" class="row justify-end q-gutter-sm q-mt-md">
           <q-btn color="primary" label="Salvar" @click="save" :loading="saving" />
           <q-btn v-if="showTransition" color="secondary" label="Salvar e Avançar" @click="saveAndAdvance" :loading="savingAdvance" />
         </div>
       </div>
     </q-card-section>
+
+    <!-- Modal for Music List -->
+    <q-dialog v-model="dialogMusicList" maximized transition-show="slide-up" transition-hide="slide-down">
+      <q-card>
+        <q-bar class="card-header">
+          <div class="text-h6">Selecionar Música</div>
+          <q-space />
+          <q-btn dense flat icon="fa fa-close" v-close-popup />
+        </q-bar>
+        <q-card-section class="q-pa-none">
+          <MusicList selectable @selected="onMusicSelected" />
+        </q-card-section>
+      </q-card>
+    </q-dialog>
+
+    <!-- Modal for Config Track -->
+    <q-dialog v-model="dialogConfigTrack">
+      <q-card style="min-width: 300px">
+        <q-card-section>
+          <div class="text-h6">Configurar Música</div>
+          <div class="text-subtitle2">{{ editingTrack?.title }} <span class="text-caption text-grey" v-if="editingTrack?.artist">— {{ editingTrack?.artist }}</span></div>
+        </q-card-section>
+
+        <q-card-section>
+          <div class="row q-col-gutter-md">
+            <div class="col-12">
+              <q-select
+                v-model="editNoteBase"
+                :options="noteOptions"
+                label="Tom (Nota)"
+                outlined
+                dense
+                emit-value
+                map-options
+              />
+            </div>
+          </div>
+          <div class="row q-mt-md">
+            <div class="col-12">
+              <q-input
+                v-model.number="editBpm"
+                label="BPM"
+                type="number"
+                outlined
+                dense
+              />
+            </div>
+          </div>
+        </q-card-section>
+
+        <q-card-actions align="right">
+          <q-btn flat label="Cancelar" color="primary" v-close-popup />
+          <q-btn flat label="Confirmar" color="primary" @click="confirmConfigTrack" />
+        </q-card-actions>
+      </q-card>
+    </q-dialog>
   </q-card>
 </template>
 
 <script setup>
-import { ref, onMounted, computed } from 'vue'
+import { ref, computed, onMounted } from 'vue'
 import { Notify } from 'quasar'
 import api from '../api'
 import { PositionOptions } from '../constants/PositionOptions'
+import MusicList from './MusicList.vue'
 
 const props = defineProps({
   scheduleId: { type: Number, required: true },
@@ -75,10 +138,24 @@ const saving = ref(false)
 const savingAdvance = ref(false)
 
 const schedule = ref({ date: null, assignedMembers: [], repertoire: [], currentAssignments: {} })
-const availableTracks = ref([])
-const selectedTracks = ref([])
 
-const availableTracksOptions = computed(() => availableTracks.value.map(t => ({ id: t.id, label: `${t.title} ${t.author ? ' — ' + t.author : ''}` })))
+const dialogMusicList = ref(false)
+const dialogConfigTrack = ref(false)
+const editingTrackIndex = ref(-1)
+const editingTrack = ref(null)
+
+const editNoteBase = ref('')
+const editNoteMode = ref('');
+const editBpm = ref('');
+
+const noteOptions = computed(() => {
+  const baseNotes = ['C','C#','D','Eb','E','F','F#','G','Ab','A','Bb','B'];
+  const isMinor = editNoteMode.value === 'minor';
+  return baseNotes.map(n => ({
+    label: n + (isMinor ? 'm' : ''),
+    value: n
+  }));
+});
 
 function formatDate(d) {
   try { return new Date(d).toLocaleDateString(); } catch { return d }
@@ -87,10 +164,10 @@ function positionLabel(value) {
   const p = PositionOptions.find(x => x.value === Number(value))
   return p ? p.label : String(value)
 }
-
-function filterTracks(term, option) {
-  if (!term) return true
-  return option.label.toLowerCase().indexOf(term.toLowerCase()) !== -1
+function formatKey(base, mode) {
+  if (!base) return '--'
+  const isMinor = mode === 'minor' ? 'm' : ''
+  return `${base}${isMinor}`
 }
 
 async function load() {
@@ -101,11 +178,15 @@ async function load() {
     schedule.value = {
       date: dto.date ?? dto.Date,
       assignedMembers: (dto.assignedMembers || dto.AssignedMembers || []).map(m => ({ id: m.id ?? m.Id, name: m.name ?? m.Name, position: m.position ?? m.Position })),
-      repertoire: (dto.repertoire || dto.Repertoire || []).map(t => ({ id: t.id ?? t.Id, title: t.title ?? t.Title, author: t.author ?? t.Author }))
+      repertoire: (dto.repertoire || dto.Repertoire || []).map(t => ({ 
+        id: t.id ?? t.Id, 
+        title: t.title ?? t.Title, 
+        artist: t.artist ?? t.Artist,
+        noteBase: t.noteBase ?? t.NoteBase,
+        noteMode: t.noteMode ?? t.NoteMode,
+        bpm: t.bpm ?? t.Bpm
+      }))
     }
-    availableTracks.value = (dto.availableTracks || dto.AvailableTracks || []).map(t => ({ id: t.id ?? t.Id, title: t.title ?? t.Title, author: t.author ?? t.Author }))
-    // initialize selectedTracks with existing repertoire track ids
-    selectedTracks.value = schedule.value.repertoire.map(t => t.id)
   } catch (err) {
     console.error(err)
     Notify.create({ type: 'negative', message: 'Erro ao carregar repertório.' })
@@ -114,10 +195,61 @@ async function load() {
   }
 }
 
+function onMusicSelected(music) {
+  dialogMusicList.value = false;
+  editingTrackIndex.value = -1;
+  editingTrack.value = music;
+  editNoteBase.value = music.noteBase || music.NoteBase || '';
+  // Se vier vazio ou diferente de minor, setamos major como padrão visual ou mantemos
+  const mode = (music.noteMode || music.NoteMode || 'major').toLowerCase();
+  editNoteMode.value = mode === 'minor' ? 'minor' : 'major';
+  editBpm.value = music.bpm || music.Bpm || '';
+  dialogConfigTrack.value = true;
+}
+
+function openConfigTrack(index) {
+  editingTrackIndex.value = index;
+  const track = schedule.value.repertoire[index];
+  editingTrack.value = track;
+  editNoteBase.value = track.noteBase || '';
+  const mode = (track.noteMode || track.NoteMode || 'major').toLowerCase();
+  editNoteMode.value = mode === 'minor' ? 'minor' : 'major';
+  editBpm.value = track.bpm || '';
+  dialogConfigTrack.value = true;
+}
+
+function confirmConfigTrack() {
+  const configuredTrack = {
+    ...editingTrack.value,
+    id: editingTrack.value.id || editingTrack.value.Id,
+    title: editingTrack.value.title || editingTrack.value.Title,
+    artist: editingTrack.value.artist || editingTrack.value.Artist,
+    noteBase: editNoteBase.value,
+    bpm: editBpm.value ? Number(editBpm.value) : null // Ignoramos gravar editNoteMode, herda o original
+  };
+
+  if (editingTrackIndex.value >= 0) {
+    schedule.value.repertoire[editingTrackIndex.value] = configuredTrack;
+  } else {
+    schedule.value.repertoire.push(configuredTrack);
+  }
+  dialogConfigTrack.value = false;
+}
+
+function removeTrack(index) {
+  schedule.value.repertoire.splice(index, 1);
+}
+
 async function save() {
   saving.value = true
   try {
-    await api.post(`schedules/${props.scheduleId}/repertoire`, selectedTracks.value);
+    const payload = schedule.value.repertoire.map(t => ({
+      musicId: t.id,
+      noteBase: t.noteBase,
+      noteMode: t.noteMode,
+      bpm: t.bpm
+    }));
+    await api.post(`schedules/${props.scheduleId}/repertoire`, payload);
     if (props.showNotify) {
       Notify.create({ type: 'positive', message: 'Repertório salvo.' })
     }
@@ -134,7 +266,6 @@ async function saveAndAdvance() {
   savingAdvance.value = true
   try {
     await save()
-    // advance to next status (2 = awaiting repertoire release) - reuse existing transition route
     await api.post('schedules/transition', { scheduleIds: [props.scheduleId], newStatus: 3 })
     Notify.create({ type: 'positive', message: 'Escala avançada.' })
     emit('advanced', props.scheduleId)

--- a/front-end/src/components/MusicList.vue
+++ b/front-end/src/components/MusicList.vue
@@ -1,0 +1,164 @@
+<template>
+  <q-card v-if="!hideSearch" class="card-content q-ma-md">
+    <q-card-section>
+      <q-form>
+        <div class="row q-col-gutter-md">
+          <div class="col-xs-12 col-sm-6 col-md-3">
+            <q-input
+              v-model="title"
+              outlined
+              dense
+              label="Título"
+              @keyup.enter="getMusics"
+              debounce="300"
+            />
+          </div>
+          <div class="col-xs-12 col-sm-6 col-md-3">
+            <q-input
+              v-model="artist"
+              outlined
+              dense
+              label="Artista"
+              @keyup.enter="getMusics"
+              debounce="300"
+            />
+          </div>
+          <div class="col-xs-12 col-sm-6 col-md-3">
+            <q-input
+              v-model="album"
+              outlined
+              dense
+              label="Álbum"
+              @keyup.enter="getMusics"
+              debounce="300"
+            />
+          </div>
+          <div class="col">
+            <q-btn
+              class="float-right"
+              color="primary"
+              label="Pesquisar"
+              no-caps
+              @click="getMusics"
+            />
+          </div>
+        </div>
+      </q-form>
+    </q-card-section>
+  </q-card>
+
+  <div class="row full-width q-pa-md">
+    <q-table
+      class="no-select full-width"
+      flat
+      bordered
+      row-key="id"
+      color="primary"
+      rows-pr-page-label="Registros por página"
+      v-model:pagination="pagination"
+      virtual-scroll
+      :rows="rows"
+      :columns="columns"
+      :loading="loading"
+      separetor="cell"
+      :rows-per-page-options="[5, 10, 15, 20, 25, 50, 100]"
+      :visible-columns="columns.filter(col => col.visible).map(col => col.name)"
+      @request="onRequest"
+    >
+      <template v-slot:body="props">
+        <q-tr :props="props">
+          <q-td key="title" @click="handleRowClick(props.row)" class="cursor-pointer">{{ props.row.title }}</q-td>
+          <q-td key="artist" @click="handleRowClick(props.row)" class="cursor-pointer">{{ props.row.artist }}</q-td>
+          <q-td key="album" @click="handleRowClick(props.row)" class="cursor-pointer">{{ props.row.album }}</q-td>
+          <q-td key="actions" v-if="!selectable && hasRole">
+            <q-btn dense flat icon="fa fa-edit" @click="editMusic(props.row.id)" />
+          </q-td>
+        </q-tr>
+      </template>
+    </q-table>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted, computed, watch } from 'vue';
+import api from "../api";
+import { ApiFilter, ApiPagination } from '../entities/ApiUtils';
+import { Role } from '../constants/Role';
+import { useAuthStore } from "../stores/authStore";
+
+const props = defineProps({
+  selectable: { type: Boolean, default: false },
+  hideSearch: { type: Boolean, default: false }
+});
+
+const emit = defineEmits(['selected', 'edit', 'open-overview']);
+
+const authStore = useAuthStore();
+const hasRole = authStore.hasAnyRole([Role.Admin, Role.Leader]);
+
+const title = ref('');
+const artist = ref('');
+const album = ref('');
+
+const filter = ApiFilter;
+const pagination = ApiPagination;
+
+const loading = ref(false);
+const rows = ref([]);
+const columns = computed(() =>[
+  { name: 'title', label: 'Título', field: 'title', align: 'left', visible: true },
+  { name: 'artist', label: 'Artista', field: 'artist', align: 'left', visible: true },
+  { name: 'album', label: 'Album', field: 'album', align: 'left', visible: true },
+  { name: 'actions', label: 'Ações', field: 'actions', align: 'right', visible: !props.selectable && hasRole }
+]);
+
+function getMusics() {
+  filter.filters = {
+    title: title.value,
+    artist: artist.value,
+    album: album.value
+  }
+
+  loading.value = true;
+  api.post('musics/list', filter).then((response) => {
+    rows.value.splice(0, rows.value.length, ...response.data.data);
+    pagination.rowsNumber = response.data.totalRecords;
+  }).finally(() => {
+    loading.value = false;
+  })
+  .catch(() => {
+    loading.value = false;
+  });
+};
+
+function onRequest(tableProps) {
+  const { page, rowsPerPage } = tableProps.pagination;
+
+  filter.page = page
+  filter.length = rowsPerPage
+
+  pagination.page = page
+  pagination.rowsPerPage = rowsPerPage
+  getMusics()
+}
+
+const handleRowClick = (row) => {
+  if (props.selectable) {
+    emit('selected', row);
+  } else {
+    emit('open-overview', row.id);
+  }
+};
+
+const editMusic = (musicId) => {
+  emit('edit', musicId);
+};
+
+onMounted(() => {
+  getMusics();
+});
+
+defineExpose({
+  getMusics
+});
+</script>

--- a/front-end/src/components/NotificationPrompt.vue
+++ b/front-end/src/components/NotificationPrompt.vue
@@ -59,7 +59,7 @@ const checkAndShowPrompt = () => {
   }
 
   if (!hasDismissed) {
-    // Atraso de 4 segundos para evitar poluição visual imediata com outros possíveis alertas no login
+    // Atraso de 2 segundos para evitar poluição visual imediata com outros possíveis alertas no login
     setTimeout(() => {
       const currentPermissionAft = ('Notification' in window) ? Notification.permission : 'denied'
       if (authStore.isAuthenticated && currentPermissionAft === 'default') {
@@ -75,7 +75,7 @@ const checkAndShowPrompt = () => {
           })
         }
       }
-    }, 4000)
+    }, 2000)
   }
 }
 

--- a/front-end/src/composables/useNotifications.js
+++ b/front-end/src/composables/useNotifications.js
@@ -76,20 +76,22 @@ export function useNotifications() {
     };
 
     // Listener para mensagens em PRIMEIRO PLANO (aba aberta e ativa)
-    onMessage(messaging, (payload) => {
-        const title = payload.notification?.title || payload.data?.title || 'WorshipHub';
-        const body = payload.notification?.body || payload.data?.body || '';
+    if (messaging) {
+        onMessage(messaging, (payload) => {
+            const title = payload.notification?.title || payload.data?.title || 'WorshipHub';
+            const body = payload.notification?.body || payload.data?.body || '';
 
-        // Em foreground, geralmente mostramos um Notify interno ou forçamos a Notificação de sistema
-        Notify.create({
-            type: 'info',
-            message: `<strong>${title}</strong><br>${body}`,
-            html: true,
-            position: 'top',
-            timeout: 5000,
-            actions: [{ label: 'Ver', color: 'white', handler: () => { router.push(payload.data?.url || '/') } }]
+            // Em foreground, geralmente mostramos um Notify interno ou forçamos a Notificação de sistema
+            Notify.create({
+                type: 'info',
+                message: `<strong>${title}</strong><br>${body}`,
+                html: true,
+                position: 'top',
+                timeout: 5000,
+                actions: [{ label: 'Ver', color: 'white', handler: () => { router.push(payload.data?.url || '/') } }]
+            });
         });
-    });
+    }
 
     const saveTokenToBackend = async (token, showNotify = true) => {
         try {

--- a/front-end/src/firebase-messaging-sw.js
+++ b/front-end/src/firebase-messaging-sw.js
@@ -20,23 +20,30 @@ self.addEventListener('activate', (event) => {
 
 const firebaseApp = initializeApp(firebaseConfig);
 
-const messaging = getMessaging(firebaseApp);
+let messaging;
+try {
+  messaging = getMessaging(firebaseApp);
+} catch (e) {
+  console.warn("Firebase Messaging is not supported in this browser SDK context.", e);
+}
 
-onBackgroundMessage(messaging, (payload) => {
-    // Tenta extrair do payload do Firebase (estrutura pode variar se vier 'notification' ou só 'data')
-    const title = payload.notification?.title || payload.data?.title || 'WorshipHub';
-    const body = payload.notification?.body || payload.data?.body || 'Nova atualização no painel.';
+if (messaging) {
+  onBackgroundMessage(messaging, (payload) => {
+      // Tenta extrair do payload do Firebase (estrutura pode variar se vier 'notification' ou só 'data')
+      const title = payload.notification?.title || payload.data?.title || 'WorshipHub';
+      const body = payload.notification?.body || payload.data?.body || 'Nova atualização no painel.';
 
-    const notificationOptions = {
-        body: body,
-        icon: '/pwa-192x192.png',
-        badge: '/vite.svg',
-        tag: 'worship-push', // Evita duplicados em sequência
-        data: { url: payload.data?.url || '/' }
-    };
+      const notificationOptions = {
+          body: body,
+          icon: '/pwa-192x192.png',
+          badge: '/vite.svg',
+          tag: 'worship-push', // Evita duplicados em sequência
+          data: { url: payload.data?.url || '/' }
+      };
 
-    self.registration.showNotification(title, notificationOptions);
-});
+      self.registration.showNotification(title, notificationOptions);
+  });
+}
 
 self.addEventListener('notificationclick', function (event) {
     event.notification.close();

--- a/front-end/src/firebase.js
+++ b/front-end/src/firebase.js
@@ -3,6 +3,12 @@ import { getMessaging, getToken, onMessage } from "firebase/messaging";
 import { firebaseConfig } from "./firebase-config";
 
 const app = initializeApp(firebaseConfig);
-const messaging = getMessaging(app);
+let messaging = null;
+
+try {
+  messaging = getMessaging(app);
+} catch (error) {
+  console.warn("Firebase Messaging is not supported:", error);
+}
 
 export { app, messaging, getToken, onMessage };

--- a/front-end/src/pages/Musics.vue
+++ b/front-end/src/pages/Musics.vue
@@ -6,87 +6,14 @@
     </q-btn>
   </div>
 
-  <q-card class="card-content q-ma-md">
-    <q-card-section>
-      <q-form>
-        <div class="row q-col-gutter-md">
-          <div class="col-xs-12 col-sm-6 col-md-3">
-            <q-input
-              v-model="title"
-              outlined
-              dense
-              label="Título"
-              @keyup.enter="getMusics"
-              debounce="300"
-            />
-          </div>
-          <div class="col-xs-12 col-sm-6 col-md-3">
-            <q-input
-              v-model="artist"
-              outlined
-              dense
-              label="Artista"
-              @keyup.enter="getMusics"
-              debounce="300"
-            />
-          </div>
-          <div class="col-xs-12 col-sm-6 col-md-3">
-            <q-input
-              v-model="album"
-              outlined
-              dense
-              label="Álbum"
-              @keyup.enter="getMusics"
-              debounce="300"
-            />
-          </div>
-          <div class="col">
-            <q-btn
-              class="float-right"
-              color="primary"
-              label="Pesquisar"
-              no-caps
-              @click="getMusics"
-            />
-          </div>
-        </div>
-      </q-form>
-    </q-card-section>
-  </q-card>
-
-  <div class="row full-width q-pa-md">
-    <q-table
-      class="no-select full-width"
-      flat
-      bordered
-      row-key="id"
-      color="primary"
-      rows-pr-page-label="Registros por página"
-      v-model:pagination="pagination"
-      virtual-scroll
-      :rows="rows"
-      :columns="columns"
-      :loading="loading"
-      separetor="cell"
-      :rows-per-page-options="[5, 10, 15, 20, 25, 50, 100]"
-      :visible-columns="columns.filter(col => col.visible).map(col => col.name)"
-      @request="onRequest"
-    >
-      <template v-slot:body="props">
-        <q-tr :props="props">
-          <q-td key="title" @click="openMusicOverview(props.row.id)" class="cursor-pointer">{{ props.row.title }}</q-td>
-          <q-td key="artist" @click="openMusicOverview(props.row.id)" class="cursor-pointer">{{ props.row.artist }}</q-td>
-          <q-td key="album" @click="openMusicOverview(props.row.id)" class="cursor-pointer">{{ props.row.album }}</q-td>
-          <q-td key="actions" v-if="hasRole">
-            <q-btn dense flat icon="fa fa-edit" @click="editMusic(props.row.id)" />
-          </q-td>
-        </q-tr>
-      </template>
-    </q-table>
-  </div>
+  <MusicList
+    ref="musicListRef"
+    @edit="editMusic"
+    @open-overview="openMusicOverview"
+  />
 
   <q-dialog v-model="dialogManageMusic" maximized transition-show="slide-up" transition-hide="slide-down">
-    <ManageMusic :musicId="selectedMusic" @updateMusicList="getMusics" @closeDialog="dialogManageMusic = false" />
+    <ManageMusic :musicId="selectedMusic" @updateMusicList="refreshList" @closeDialog="dialogManageMusic = false" />
   </q-dialog>
 
   <q-dialog
@@ -100,9 +27,8 @@
 </template>
 
 <script setup>
-import { ref, onMounted, computed } from 'vue';
-import api from "../api";
-import { ApiFilter, ApiPagination } from '../entities/ApiUtils';
+import { ref } from 'vue';
+import MusicList from '../components/MusicList.vue';
 import ManageMusic from '../components/ManageMusic.vue';
 import MusicOverview from '../components/MusicOverview.vue';
 import { Role } from '../constants/Role';
@@ -111,53 +37,10 @@ import { useAuthStore } from "../stores/authStore";
 const authStore = useAuthStore();
 const hasRole = authStore.hasAnyRole([Role.Admin, Role.Leader]);
 
-const title = ref('');
-const artist = ref('');
-const album = ref('');
 const dialogManageMusic = ref(false);
 const dialogMusic = ref(false);
 const selectedMusic = ref(null);
-
-const filter = ApiFilter;
-const pagination = ApiPagination;
-
-const loading = ref(false);
-const rows = ref([]);
-const columns = computed(() =>[
-  { name: 'title', label: 'Título', field: 'title', align: 'left', visible: true },
-  { name: 'artist', label: 'Artista', field: 'artist', align: 'left', visible: true },
-  { name: 'album', label: 'Album', field: 'album', align: 'left', visible: true },
-  { name: 'actions', label: 'Ações', field: 'actions', align: 'right', visible: hasRole }
-]);
-
-function getMusics() {
-  filter.filters = {
-    title: title.value,
-    artist: artist.value,
-    album: album.value
-  }
-
-  loading.value = true;
-  api.post('musics/list', filter).then((response) => {
-    rows.value.splice(0, rows.value.length, ...response.data.data);
-    pagination.rowsNumber = response.data.totalRecords;
-  }).finally(() => {
-    loading.value = false;
-  })
-  .catch(() => {
-    loading.value = false;
-  });
-};
-
-function onRequest(props) {
-  const { page, rowsPerPage } = props.pagination;
-
-  filter.page = page
-  filter.length = rowsPerPage
-
-  pagination.page = page
-  pagination.rowsPerPage = rowsPerPage
-}
+const musicListRef = ref(null);
 
 const editMusic = (musicId) => {
   selectedMusic.value = musicId;
@@ -165,11 +48,13 @@ const editMusic = (musicId) => {
 };
 
 function openMusicOverview(musicId) {
-  selectedMusic.value = musicId
-  dialogMusic.value = true
+  selectedMusic.value = musicId;
+  dialogMusic.value = true;
 }
 
-onMounted(() => {
-  getMusics();
-});
+function refreshList() {
+  if (musicListRef.value) {
+    musicListRef.value.getMusics();
+  }
+}
 </script>


### PR DESCRIPTION
- (backend: adicionado suporte para sobrescrever 'note_base' e 'bpm' na tabela 'schedules_musics'.
- backend: inserida a instrução COALESCE nos repositórios (Schedule e Home) para fazer fallback das customizações vs propriedades originais da música.
- backend: DTOs e endpoint da Home refatorados para devolver propriedades individuais ao invés de string engessada.
- frontend: extraída a lógica da tabela de músicas para um novo componente reaproveitável 'MusicList.vue'.
- frontend: substituído dropdown simples por modal de busca robusta (MusicList) no painel de gerenciamento de repertório.
- frontend: adicionada modal de "Configuração de Música" na escala para personalizar o Tom (Nota Base) e BPM na hora da inserção, herdando dinamicamente o Modo da música original.
- frontend: refatorada a exibição dos detalhes das músicas na HomePage do membro para suportar marcações em negrito (Vue style).
- fix: adicionado try/catch na inicialização do Firebase Messaging Service Worker para evitar crash em ambientes locais sem HTTPS/Push API nativa.

Closes #44 